### PR TITLE
replace_na behaviour changed in tidy - throws error now - this should…… fix it

### DIFF
--- a/vignettes/narrative.Rmd
+++ b/vignettes/narrative.Rmd
@@ -76,7 +76,7 @@ When we format these data (which we'll provide toolchains for at the end), the w
 
 ```{r echo=FALSE}
 buffer_example %>%
-  mutate(across(everything(), replace_na, "")) %>%
+  mutate(across(where(is.character), replace_na, "")) %>%
   select(short_title, contains("spatial")) %>%
   kable() 
 ```


### PR DESCRIPTION
From the changelog for tidyr:

"replace_na() no longer allows the type of data to change when the replacement is applied. replace will now always be cast to the type of data before the replacement is made. For example, this means that using a replacement value of 1.5 on an integer column is no longer allowed. Similarly, replacing missing values in a list-column must now be done with list("foo") rather than just "foo"."